### PR TITLE
Exhaustive checking example for string literals

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -512,6 +512,18 @@ function createElement(tagName: string): Element {
 }
 ```
 
+To create an exhaustive mapping from a string literal type, you could use a map:
+```ts
+type Easing = "ease-in" | "ease-out" | "ease-in-out";
+
+const animationTimings: {[T in Easing]: string} = {
+    "ease-in": "100ms",
+    "ease-out": "200ms",
+    "ease-in-out": "100ms"
+};
+```
+Now if you add or remove a string from the string literal type ```Easing```, TypeScript will recognize that you are missing the key in ```animationTimings```.  
+
 # Discriminated Unions
 
 You can combine string literal types, union types, type guards, and type aliases to build an advanced pattern called *discriminated unions*, also known as *tagged unions* or *algebraic data types*.


### PR DESCRIPTION
As the documentation is very helpful to me, I was trying to find a nice way to require all enumerations to map to a value. As documentation I'm looking for should be close to the documentation that 'owns it', I thought adding it here would be helpful to others.

Please let me know if I should make an issue before hand. The contributing file doesn't say I have to, and I scanned the list and found one that added the Discriminating Unions #330 but could be elaborated on to add this example. 

Works on 2.2